### PR TITLE
👥 Publish on both npm and GitHub 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,11 +19,16 @@ jobs:
       - id: set-matrix
         run: echo "::set-output name=schema::$(ls schema/ | jq -R -s -c 'split("\n")[:-1]' )"
 
-  publish-npm-okp4:
+  publish-npm-package:
     runs-on: ubuntu-22.04
     needs: schema-matrix
     strategy:
       matrix:
+        registry:
+          - url: "https://npm.pkg.github.com"
+            auth-token-secret: NPM_REGISTRY_TOKEN
+          - url: "https://registry.npmjs.org"
+            auth-token-secret: NPM_PUBLIC_REGISTRY_TOKEN
         schema: ${{ fromJson(needs.schema-matrix.outputs.schema) }}
     steps:
       - name: Check out repository
@@ -37,7 +42,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18.12
-          registry-url: "https://npm.pkg.github.com"
+          registry-url: ${{ matrix.registry.url }}
           scope: "@okp4"
 
       - name: Installing quicktype
@@ -61,16 +66,12 @@ jobs:
         run: |
           set -eu
 
-          DATE=$(date +%Y%m%d%H%M%S)
-
           yarn --cwd ${{ steps.package.outputs.DESTINATION }} && yarn --cwd ${{ steps.package.outputs.DESTINATION }} build
-
-          publish=(yarn --cwd ${{ steps.package.outputs.DESTINATION }} publish --no-git-tag-version --non-interactive)
+          DATE=$(date +%Y%m%d%H%M%S)
+          publish=(yarn --cwd ${{ steps.package.outputs.DESTINATION }} publish --access=public --no-git-tag-version --non-interactive)
 
           if [[ $GITHUB_REF == refs/tags/v* ]]; then
             publish+=(--tag latest)
-          elif [[ $GITHUB_EVENT_NAME == pull_request ]]; then
-            publish+=(--prerelease --preid ${{ env.CI_ACTION_REF_NAME_SLUG }}.$DATE --tag ${{ env.CI_ACTION_REF_NAME_SLUG }})
           else
             publish+=(--prerelease --preid next.$DATE --tag next)
           fi
@@ -78,56 +79,4 @@ jobs:
           echo "🚀 Publishing npm package with following command line: ${publish[@]}"
           "${publish[@]}"
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
-
-  publish-npm-public:
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
-    runs-on: ubuntu-22.04
-    needs: schema-matrix
-    strategy:
-      matrix:
-        schema: ${{ fromJson(needs.schema-matrix.outputs.schema) }}
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v3
-
-      - name: Set up context
-        id: project_context
-        uses: FranzDiebold/github-env-vars-action@v2.7.0
-
-      - name: Setup node environment (for publishing)
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18.12
-          registry-url: "https://registry.npmjs.org"
-          scope: "@okp4"
-
-      - name: Installing quicktype
-        run: |
-          yarn global add quicktype
-          echo "$(yarn global bin)" >> $GITHUB_PATH
-
-      - name: Prepare package path
-        id: package
-        run: |
-          SCHEMA=${{ matrix.schema }}
-          PACKAGE_SRC=$(echo "ts/${SCHEMA/okp4-/""}-schema")
-          mkdir ${PACKAGE_SRC}/gen-ts
-          echo "DESTINATION=$(echo "ts/${SCHEMA/okp4-/""}-schema")" >> $GITHUB_OUTPUT
-
-      - name: Generate sources
-        run: |
-          quicktype -s schema schema/${{ matrix.schema }}/*.json -o ${{ steps.package.outputs.DESTINATION }}/gen-ts/schema.ts --prefer-types
-
-      - name: Publish package
-        run: |
-          set -eu
-
-          yarn --cwd ${{ steps.package.outputs.DESTINATION }} && yarn --cwd ${{ steps.package.outputs.DESTINATION }} build
-
-          publish=(yarn --cwd ${{ steps.package.outputs.DESTINATION }} publish --access=public --no-git-tag-version --non-interactive --tag latest)
-
-          echo "🚀 Publishing npm package with following command line: ${publish[@]}"
-          "${publish[@]}"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLIC_REGISTRY_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets[matrix.registry.auth-token-secret] }}

--- a/ts/cognitarium-schema/package.json
+++ b/ts/cognitarium-schema/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@okp4/cognitarium-schema",
-    "version": "1.0.0",
+    "version": "2.1.0",
     "private": false,
     "repository": {
         "type": "git",

--- a/ts/law-stone-schema/package.json
+++ b/ts/law-stone-schema/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@okp4/law-stone-schema",
-    "version": "1.0.0",
+    "version": "2.1.0",
     "private": false,
     "repository": {
         "type": "git",

--- a/ts/objectarium-schema/package.json
+++ b/ts/objectarium-schema/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@okp4/objectarium-schema",
-    "version": "1.0.0",
+    "version": "2.1.0",
     "private": false,
     "repository": {
         "type": "git",


### PR DESCRIPTION
Change publish workflow to publish publicly on both npm registry and GitHub package registry like is done on [@okp4/ui](https://github.com/okp4/ui/blob/main/.github/workflows/publish.yml) for release and next release. 

I've also aligned the okp4/contracts version with those schemas package in `package.json`.