### PR TITLE
fix(ts): add typesVersions options for remove dist folder

### DIFF
--- a/ts/cognitarium-schema/package.json
+++ b/ts/cognitarium-schema/package.json
@@ -28,5 +28,8 @@
         "clean": "rm -rf gen-ts && mkdir gen-ts",
         "build": "tsc"
     },
-    "exports": "./dist/schema.d.ts"
+    "exports": "./dist/schema.d.ts",
+    "typesVersions": {
+        "*": { ".": ["./dist/schema.d.ts"] }
+    }
 }

--- a/ts/cognitarium-schema/package.json
+++ b/ts/cognitarium-schema/package.json
@@ -29,7 +29,5 @@
         "build": "tsc"
     },
     "exports": "./dist/schema.d.ts",
-    "typesVersions": {
-        "*": { ".": ["./dist/schema.d.ts"] }
-    }
+    "types": "./dist/schema.d.ts"
 }

--- a/ts/law-stone-schema/package.json
+++ b/ts/law-stone-schema/package.json
@@ -28,5 +28,8 @@
         "clean": "rm -rf gen-ts && mkdir gen-ts",
         "build": "tsc"
     },
-    "exports": "./dist/schema.d.ts"
+    "exports": "./dist/schema.d.ts",
+    "typesVersions": {
+        "*": { ".": ["./dist/schema.d.ts"] }
+    }
 }

--- a/ts/law-stone-schema/package.json
+++ b/ts/law-stone-schema/package.json
@@ -29,7 +29,5 @@
         "build": "tsc"
     },
     "exports": "./dist/schema.d.ts",
-    "typesVersions": {
-        "*": { ".": ["./dist/schema.d.ts"] }
-    }
+    "types": "./dist/schema.d.ts"
 }

--- a/ts/objectarium-schema/package.json
+++ b/ts/objectarium-schema/package.json
@@ -28,5 +28,8 @@
         "clean": "rm -rf gen-ts && mkdir gen-ts",
         "build": "tsc"
     },
-    "exports": "./dist/schema.d.ts"
+    "exports": "./dist/schema.d.ts",
+    "typesVersions": {
+        "*": { ".": ["./dist/schema.d.ts"] }
+    }
 }

--- a/ts/objectarium-schema/package.json
+++ b/ts/objectarium-schema/package.json
@@ -29,7 +29,5 @@
         "build": "tsc"
     },
     "exports": "./dist/schema.d.ts",
-    "typesVersions": {
-        "*": { ".": ["./dist/schema.d.ts"] }
-    }
+    "types": "./dist/schema.d.ts"
 }


### PR DESCRIPTION
When using `ESNext` for `module` option in addition with `Node` in `moduleResolution` options of `tsconfig.json`, the `dist` folder is not omitted when trying to import schema type. I hope this one will fix it 🤞.