### PR TITLE
[TS] Use union for enum generation 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Generate sources
         run: |
-          quicktype -s schema schema/${{ matrix.schema }}/*.json -o ${{ steps.package.outputs.DESTINATION }}/gen-ts/schema.ts --prefer-types
+          quicktype -s schema schema/${{ matrix.schema }}/*.json -o ${{ steps.package.outputs.DESTINATION }}/gen-ts/schema.ts --prefer-types --prefer-unions
 
       - name: Fetch dependencies
         run: yarn --cwd ${{ steps.package.outputs.DESTINATION }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Generate sources
         run: |
-          quicktype -s schema schema/${{ matrix.schema }}/*.json -o ${{ steps.package.outputs.DESTINATION }}/gen-ts/schema.ts --prefer-types
+          quicktype -s schema schema/${{ matrix.schema }}/*.json -o ${{ steps.package.outputs.DESTINATION }}/gen-ts/schema.ts --prefer-types --prefer-unions
 
       - name: Publish package
         run: |


### PR DESCRIPTION
Since enum is not working nice (#9), I've add an option on QuickType typescript generation to prefer union for enum instead of enum type. This will not #9 for the enum name but I hope it will resolve the import issue.