### PR TITLE
🚀 Create a release on tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -89,3 +89,9 @@ jobs:
           "${publish[@]}"
         env:
           NODE_AUTH_TOKEN: ${{ secrets[matrix.registry.auth-token-secret] }}
+
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          body: Schema changelog avalaible on [contract repository](https://github.com/okp4/contracts/blob/${{ github.ref_name }}/CHANGELOG.md).


### PR DESCRIPTION
Just a little PR to automatically create a GitHub release when a new tag is publish. It's allow later for other language to include artefact on the release tab. 